### PR TITLE
Remove duplicated user declaration / configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,5 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o telemetr
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/telemetry .
-USER nonroot:nonroot
 ENV GIN_MODE release
 ENTRYPOINT ["/telemetry"]


### PR DESCRIPTION
The image is already running as nonroot, specified via the image tag (`gcr.io/distroless/static:nonroot`) Specifing it here again using the username makes deploying it to kubernetes slightly more annoying as this failed the `runAsNonRoot` securityContext check as kubernetes can't verify that this is actually non-root as it's not configured via the uid.